### PR TITLE
Add output name cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ The file watching is done using [fsnotify](https://github.com/go-fsnotify/fsnoti
 Simply go to your desired directory (for example, $GOPATH/src/myBadassGoProject) and run the following:
 
 ```sh
-  gowatch [options] 
+  gowatch [options]
 ```
 
 ### Options:
 
 Note: the option that is set on each argument below is the current default if not passed.
+
+`-output=""`the name of the program to output
 
 `-args=""`CLI arguments passed to the app
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	ignore         = flag.String("ignore", ".git/*,node_modules/*", "")
 	restartOnExit  = flag.Bool("onexit", true, "")
 	restartOnError = flag.Bool("onerror", true, "")
+	outputName     = flag.String("output", "", "")
 	appArgs        = flag.String("args", "", "")
 	shouldTest     = flag.Bool("test", true, "")
 	shouldLint     = flag.Bool("lint", true, "")
@@ -30,6 +31,7 @@ var (
 func init() {
 	flag.Usage = func() {
 		fmt.Printf("%s options\n%s\n", os.Args[0], strings.Join([]string{
+			color.GreenString("  -output") + "=\"\": the name of the program to output",
 			color.GreenString("  -args") + "=\"\": arguments to pass to the underlying app",
 			color.GreenString("  -debug") + "=false: enabled debug print statements",
 			color.GreenString("  -ignore") + "=\".git/*,node_modules/*\": comma delimited paths to ignore in the file watcher",
@@ -60,7 +62,7 @@ func handleWatch(projectPath string, ignorePaths []string) {
 	for {
 		gwl.LogDebug("---Starting app monitor---")
 		time.Sleep(*wait)
-		execHandle := project.ExecuteBuildSteps(projectPath, *appArgs, *shouldTest, *shouldLint)
+		execHandle := project.ExecuteBuildSteps(projectPath, *outputName, *appArgs, *shouldTest, *shouldLint)
 
 		gwl.LogDebug("---Setting up watch cb---")
 		watchHandle.Subscribe(func(fileName string) {

--- a/project/build.go
+++ b/project/build.go
@@ -5,8 +5,8 @@ import (
 	"os/exec"
 )
 
-func build(projectDirectory string) bool {
-	cmd := exec.Command("go", "build")
+func build(projectDirectory string, outputName string) bool {
+	cmd := exec.Command("go", "build", "-o", outputName)
 	cmd.Dir = projectDirectory
 	cmd.Env = os.Environ()
 

--- a/project/project.go
+++ b/project/project.go
@@ -6,7 +6,7 @@ import (
 	gwl "github.com/adamveld12/gowatch/log"
 )
 
-func ExecuteBuildSteps(projectDirectory, appArguments string, shouldTest bool, shouldLint bool) *ExecuteHandle {
+func ExecuteBuildSteps(projectDirectory, outputName string, appArguments string, shouldTest bool, shouldLint bool) *ExecuteHandle {
 
 	handle := &ExecuteHandle{
 		sync.Mutex{},
@@ -18,14 +18,14 @@ func ExecuteBuildSteps(projectDirectory, appArguments string, shouldTest bool, s
 		nil,
 	}
 
-	if !build(projectDirectory) {
+	if !build(projectDirectory, outputName) {
 		handle.Kill(ErrorBuildFailed)
 	} else if shouldLint && !lint(projectDirectory) {
 		handle.Kill(ErrorLintFailed)
 	} else if shouldTest && !test(projectDirectory) {
 		handle.Kill(ErrorTestFailed)
 	} else {
-		handle.start(run(projectDirectory, appArguments))
+		handle.start(run(projectDirectory, outputName, appArguments))
 	}
 
 	gwl.LogDebug("[DEBUG] build steps completed")

--- a/project/run.go
+++ b/project/run.go
@@ -106,9 +106,17 @@ func (h *ExecuteHandle) start(cmd *exec.Cmd) {
 	<-waiter
 }
 
-func run(projectDirectory, arguments string) *exec.Cmd {
-	_, command := filepath.Split(projectDirectory)
+func run(projectDirectory, programName string, arguments string) *exec.Cmd {
+	command := ""
+
+	if programName != "" {
+		command = programName
+	} else {
+		_, command = filepath.Split(projectDirectory)
+	}
+
 	cmd := exec.Command("./"+command, arguments)
+
 	cmd.Dir = projectDirectory
 	cmd.Env = os.Environ()
 


### PR DESCRIPTION
This pull request adds a command line argument, `output`, which allows the user to set the filename of the executable that is built and run.

This argument is optional, and if omitted results in the current default behavior.
